### PR TITLE
Add plugin setting to make inclusion of parameter units optional

### DIFF
--- a/inventree_kicad/KiCadLibraryPlugin.py
+++ b/inventree_kicad/KiCadLibraryPlugin.py
@@ -168,6 +168,12 @@ class KiCadLibraryPlugin(UrlsMixin, AppMixin, SettingsMixin, SettingsContentMixi
             'description': _('This identifier specifies what key the import tool looks for to get the part ID'),
             'default': "InvenTree"
         },
+        'KICAD_INCLUDE_UNITS_IN_PARAMETERS': {
+            'name': _('Include units in parameters'),
+            'description': _('When activated, if a parameter has units it will be included'),
+            'validator': bool,
+            'default': True,
+        },
     }
 
     def get_settings_content(self, request):

--- a/inventree_kicad/serializers.py
+++ b/inventree_kicad/serializers.py
@@ -323,6 +323,9 @@ class KicadDetailedPartSerializer(serializers.ModelSerializer):
         except AttributeError:
             pass  # ignore if there are any issues
 
+        # Check if we should include the parameter units in custom parameters
+        kicad_include_units_in_parameters = self.plugin.get_setting('KICAD_INCLUDE_UNITS_IN_PARAMETERS', True)
+
         for parameter in part.parameters.all():
             # Exclude any which have already been used for default KiCad fields
             if str(parameter.template.pk) in excluded_templates:
@@ -338,8 +341,12 @@ class KicadDetailedPartSerializer(serializers.ModelSerializer):
             if kicad_local_field_visibility is not None:
                 is_visible = 'True' if parameter.template.name.lower().strip() in kicad_local_field_visibility else 'False'
 
+            units = ""
+            if kicad_include_units_in_parameters:
+                units = f" {parameter.units}"
+
             fields[parameter.template.name] = {
-                "value": f'{parameter.data} {parameter.units}'.strip(),
+                "value": f'{parameter.data}{units}'.strip(),
                 "visible": is_visible
             }
 


### PR DESCRIPTION
[Commit `d5eb5d1`](https://github.com/afkiwers/inventree_kicad/commit/d5eb5d1c476f06de0b1d9c1a82d5ee1b643ba0cf) changed the behavior for custom fields to have the units included. I preferred the previous behavior where just the value was exported. This PR creates a Plugin setting to optionally revert back to the old behavior (and defaults to the new "include units" behavior).

I forked and am using this now, but thought I'd throw it up for PR to see if it's worth having upstream. Open to any feedback as this was just quickly thrown together for myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a setting to let users choose whether units are included with parameter values.
* **Improvements**
  * Parameter units can now be optionally displayed or hidden based on user preference, altering how parameter values are presented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->