### PR TITLE
Update fallback value for part name retrieval

### DIFF
--- a/inventree_kicad/serializers.py
+++ b/inventree_kicad/serializers.py
@@ -239,7 +239,7 @@ class KicadDetailedPartSerializer(serializers.ModelSerializer):
         """
 
         # Fallback to the part name
-        value = part.full_name
+        value = part.name
 
         # Find the value parameter value associated with this part instance
         template_id = self.plugin.get_setting('KICAD_VALUE_PARAMETER', None)
@@ -247,7 +247,7 @@ class KicadDetailedPartSerializer(serializers.ModelSerializer):
         value = self.get_parameter_value(part, template_id, backup_value=value)
 
         # it looks like there's not value parameter specified
-        if value == part.full_name:
+        if value == part.name:
             # Fallback to the "default" value parameter for the associated SelectedCategory instance
             if kicad_category := self.get_kicad_category(part):
                 value_parameter = kicad_category.default_value_parameter_template


### PR DESCRIPTION
This changes the Fallback of the get_value function to only use `part.name` instead of `part.full_name` because full_name uses the default formatter. So it will also include more things like IPN, Revision etc. I think its more intuitive for it to just display the name, since there is an setting to use IPN instead of name already
<img width="272" height="159" alt="image" src="https://github.com/user-attachments/assets/f7349bfc-3541-4a68-99c3-aff6aa9acf89" />
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrects how default parameter values are applied by aligning comparisons with the part’s display name, improving consistency when the full name contains additional qualifiers.
  * Prevents unintended overrides and missing defaults, ensuring expected parameter values appear consistently in detailed part views and related outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->