### PR TITLE
Account for variants and allocations in stock count calculation

### DIFF
--- a/inventree_kicad/serializers.py
+++ b/inventree_kicad/serializers.py
@@ -2,6 +2,7 @@ import logging
 
 from django.utils.translation import gettext_lazy as _
 from django.db.models import ExpressionWrapper, F, DecimalField
+from django.db.models.functions import Greatest
 
 from rest_framework import serializers
 from rest_framework.reverse import reverse_lazy
@@ -539,10 +540,14 @@ class KicadPreviewPartSerializer(serializers.ModelSerializer):
         # Annotate with the total 'available stock' quantity
         # This is the current stock, minus any allocations
         queryset = queryset.annotate(
-            unallocated_stock=ExpressionWrapper(
-                F('total_in_stock')
-                - F('allocated_to_sales_orders')
-                - F('allocated_to_build_orders'),
+            unallocated_stock=Greatest(
+                ExpressionWrapper(
+                    F('total_in_stock')
+                    - F('allocated_to_sales_orders')
+                    - F('allocated_to_build_orders'),
+                    output_field=DecimalField(),
+                ),
+                0,
                 output_field=DecimalField(),
             )
         )


### PR DESCRIPTION
Currently, the stock count provided to KiCAD does not include part variants, and includes stock that has already been allocated to sales / build orders.
This PR changes it to match the number shown in the "part" user interface, i.e. including variants and excluding allocated stock.
This fixes https://github.com/afkiwers/inventree_kicad/issues/103
Thanks SchrodingersGat for pointing me in the right direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stock display now reflects available (unallocated) quantities by combining on-hand and variant stock and subtracting allocations to orders.
  * Added visibility of "Total In Stock" and "Available Stock" in both detailed and preview KiCad part views.
  * Stock and description sections now use available stock for clearer, real-world availability.
  * Improved accuracy for parts with variants, aggregating variant stock and exposing allocation-aware totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->