### PR TITLE
Add MAX_VERSION attribute

### DIFF
--- a/inventree_kicad/KiCadLibraryPlugin.py
+++ b/inventree_kicad/KiCadLibraryPlugin.py
@@ -57,6 +57,7 @@ class KiCadLibraryPlugin(UrlsMixin, AppMixin, SettingsMixin, SettingsContentMixi
     WEBSITE = "https://github.com/afkiwers"
 
     MIN_VERSION = '0.12.0'
+    MAX_VERSION = '1.1.99'
 
     SETTINGS = {
         'KICAD_ENABLE_SUBCATEGORY': {


### PR DESCRIPTION
- Must be merged and release before https://github.com/afkiwers/inventree_kicad/pull/135
- Adds a "MAX_VERSION" of `1.1.99`
- Prevents this version of the plugin from being used with a server of `1.2.0` or above